### PR TITLE
Fix CapsLock toggling while using as BackSpace with Xmodmap

### DIFF
--- a/xmodmap/xmodmap.norman
+++ b/xmodmap/xmodmap.norman
@@ -53,7 +53,7 @@ keycode  59 =        comma          less     dead_cedilla        asciitilde
 keycode  60 =       period       greater    dead_abovedot        asciitilde            
 keycode  61 =        slash      question     questiondown        asciitilde            
                                                                                       
-keycode  66 =    BackSpace     Caps_Lock        Caps_Lock         Caps_Lock            
+keycode  66 =    BackSpace     BackSpace        Caps_Lock         Caps_Lock            
 keycode  94 =        minus    underscore           endash            emdash            
 keycode  65 =        space         space            space      nobreakspace            
 keycode 108 =  Mode_switch   Mode_switch                                               


### PR DESCRIPTION
Previously CapsLock toggled and BackSpace was triggered
while using the CapsLock key. Now, the CapsLock key only
triggers a BackSpace.
