### PR TITLE
Fix broken Ctrl-key sequences in Cocoa Text fields on Mac OS X. Fixes #4

### DIFF
--- a/mac/Norman.bundle/Contents/Resources/Norman.keylayout
+++ b/mac/Norman.bundle/Contents/Resources/Norman.keylayout
@@ -828,24 +828,24 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="7">
-            <key code="0" output="a"/>
-            <key code="1" output="s"/>
-            <key code="2" output="e"/>
-            <key code="3" output="t"/>
-            <key code="4" output="y"/>
-            <key code="5" output="g"/>
-            <key code="6" output="z"/>
-            <key code="7" output="x"/>
-            <key code="8" output="c"/>
-            <key code="9" output="v"/>
+            <key code="0" output="&#x0001;"/>
+            <key code="1" output="&#x0013;"/>
+            <key code="2" output="&#x0005;"/>
+            <key code="3" output="&#x0014;"/>
+            <key code="4" output="&#x0019;"/>
+            <key code="5" output="&#x0007;"/>
+            <key code="6" output="&#x001A;"/>
+            <key code="7" output="&#x0018;"/>
+            <key code="8" output="&#x0003;"/>
+            <key code="9" output="&#x0016;"/>
             <key code="10" output="0"/>
-            <key code="11" output="b"/>
-            <key code="12" output="q"/>
-            <key code="13" output="w"/>
-            <key code="14" output="d"/>
-            <key code="15" output="f"/>
-            <key code="16" output="j"/>
-            <key code="17" output="k"/>
+            <key code="11" output="&#x0002;"/>
+            <key code="12" output="&#x0011;"/>
+            <key code="13" output="&#x0017;"/>
+            <key code="14" output="&#x0004;"/>
+            <key code="15" output="&#x0006;"/>
+            <key code="16" output="&#x000A;"/>
+            <key code="17" output="&#x000B;"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
             <key code="20" output="3"/>
@@ -855,26 +855,26 @@
             <key code="24" output="="/>
             <key code="25" output="9"/>
             <key code="26" output="7"/>
-            <key code="27" output="-"/>
+            <key code="27" output="&#x001F;"/>
             <key code="28" output="8"/>
             <key code="29" output="0"/>
-            <key code="30" output="]"/>
-            <key code="31" output="l"/>
-            <key code="32" output="u"/>
-            <key code="33" output="["/>
-            <key code="34" output="r"/>
+            <key code="30" output="&#x001D;"/>
+            <key code="31" output="&#x000C;"/>
+            <key code="32" output="&#x0015;"/>
+            <key code="33" output="&#x001B;"/>
+            <key code="34" output="&#x0012;"/>
             <key code="35" output=";"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="o"/>
-            <key code="38" output="n"/>
+            <key code="37" output="&#x000F;"/>
+            <key code="38" output="&#x000E;"/>
             <key code="39" output="&#x0027;"/>
-            <key code="40" output="i"/>
-            <key code="41" output="h"/>
-            <key code="42" output="\"/>
+            <key code="40" output="&#x0009;"/>
+            <key code="41" output="&#x0008;"/>
+            <key code="42" output="&#x001C;"/>
             <key code="43" output=","/>
             <key code="44" output="/"/>
-            <key code="45" output="p"/>
-            <key code="46" output="m"/>
+            <key code="45" output="&#x0010;"/>
+            <key code="46" output="&#x000D;"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="5"/>


### PR DESCRIPTION
Recreated the layout by using Ukelele 'base on current input source' (U.S.) and then updating
current Norman.keylayout file.
